### PR TITLE
Python3 support (PY3 only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*pycache*
+*.pyc
+.*.swp
+*.egg-info
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "nightly"
+sudo: false
+install:
+  - which pip3 && pip3 install --upgrade coverage || pip install --upgrade coverage
+script:
+  - coverage run --branch --omit *_test.py xid_test.py --verbose && coverage report -m --fail-under=90 

--- a/base32hex.py
+++ b/base32hex.py
@@ -101,7 +101,7 @@ def decode(src, str_map):
         if src_len >= 2:
             dst[0] = (dbuf[0] << 3) | (dbuf[1] >> 2)
 
-        dst = map(lambda x: x & 0xff, dst)
+        dst = list(map(lambda x: x & 0xff, dst))
 
         if src_len == 2:
             dst = dst[:1]
@@ -121,7 +121,7 @@ def decode(src, str_map):
 
 
 def b32encode(src):
-    return encode(map(ord, src), encodeHex)
+    return encode(list(map(ord, src)), encodeHex)
 
 
 def b32decode(src):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.4',
+    version='1.0.5',
 
     description='Python Xid Implementation',
     long_description=long_description,

--- a/xid.py
+++ b/xid.py
@@ -12,7 +12,10 @@ import threading
 import base32hex
 
 # MyPy imports
-from typing import List
+try:
+  from typing import List
+except:
+  pass # ignore, we do not need the typing module
 
 # Some Constants
 trimLen = 20
@@ -25,8 +28,8 @@ class InvalidXid(Exception):
 
 def randInt():
     # type: () -> int
-    buf = os.urandom(3)
-    buford = map(ord, buf)
+    buf = str(os.urandom(3))
+    buford = list(map(ord, buf))
     return buford[0] << 16 | buford[1] << 8 | buford[2]
 
 def realMachineID():
@@ -34,12 +37,12 @@ def realMachineID():
     try:
         hostname = platform.node()
         hw = hashlib.md5()
-        hw.update(hostname)
-        val = hw.digest()[:3]
-        return map(ord, val)
+        hw.update(hostname.encode('utf-8'))
+        val = str(hw.digest()[:3])
+        return list(map(ord, val))
     except:
         buf = os.urandom(3)
-        return map(ord, buf)
+        return list(map(ord, buf))
 
 ## Module level items
 pid = os.getpid()
@@ -75,7 +78,7 @@ def generate_new_xid():
     id[7] = (pid >> 8) & 0xff
     id[8] = (pid) & 0xff
 
-    i = objectIDGenerator.next()
+    i = next(objectIDGenerator)
 
     id[9] = (i >> 16) & 0xff
     id[10] = (i >> 8) & 0xff


### PR DESCRIPTION
fix #1 
- bump version to 1.0.5
- add travis build (python 2.7, 3.3 and up incl. nightly)
- please add travis to your repo config
- made the typing module an optional import
- now collects test coverage on verbose test run and reports coverage results
- failing builds are due to coverage being less than 90%