### PR TITLE
Allowing bytes to have the value of zero

### DIFF
--- a/xid.py
+++ b/xid.py
@@ -146,7 +146,7 @@ class Xid(object):
     def from_string(cls, s):
         # type: (str) -> Xid
         val = base32hex.b32decode(s.upper())
-        value_check = [0 < x < 255 for x in val]
+        value_check = [0 <= x < 255 for x in val]
 
         if not all(value_check):
             raise InvalidXid(s)


### PR DESCRIPTION
The value check disallowed the value 0 for decoded bytes.

I believe this is allowed in valid XIDs