### PR TITLE
Allow bytes to have the the 255 value

### DIFF
--- a/xid.py
+++ b/xid.py
@@ -146,7 +146,7 @@ class Xid(object):
     def from_string(cls, s):
         # type: (str) -> Xid
         val = base32hex.b32decode(s.upper())
-        value_check = [0 <= x < 255 for x in val]
+        value_check = [0 <= x <= 255 for x in val]
 
         if not all(value_check):
             raise InvalidXid(s)


### PR DESCRIPTION
This should fix the issue in #5 

It looks like the logic in `from_string` is off by 1. The 255 bytes will not pass the test.